### PR TITLE
[18.0][IMP] tier_validation_dynamic_state: check for valid tiers instead search only by states

### DIFF
--- a/tier_validation_dynamic_state/models/tier_validation.py
+++ b/tier_validation_dynamic_state/models/tier_validation.py
@@ -134,8 +134,9 @@ class TierValidation(models.AbstractModel):
                 ],
             )
         )
+        valid_tiers = any([self.evaluate_tier(tier) for tier in tier_definitions])
 
-        if not tier_definitions:
+        if not valid_tiers:
             return False
 
         current_reviews = self.review_ids.filtered(

--- a/tier_validation_dynamic_state/tests/test_tier_validation_dynamic_state.py
+++ b/tier_validation_dynamic_state/tests/test_tier_validation_dynamic_state.py
@@ -123,3 +123,12 @@ class TestTierValidationDynamicState(CommonTierValidation):
         vals = self.test_record._prepare_tier_review_vals(self.tier_def_1, 1)
         self.assertEqual(vals["state_from"], "draft")
         self.assertEqual(vals["state_to"], "confirmed")
+
+    def test_check_and_request_tier_no_definition(self):
+        record = self.test_record
+
+        res = record._check_and_request_tier("cancel")
+        self.assertFalse(res)
+
+        record.write({"state": "cancel"})
+        self.assertEqual(record.state, "cancel")


### PR DESCRIPTION
@Escodoo HT01486

cc: @marcelsavegnago @CristianoMafraJunior @kaynnan 